### PR TITLE
Fixes to scanning's testing

### DIFF
--- a/scanning/problem.lua
+++ b/scanning/problem.lua
@@ -47,6 +47,6 @@ local function eq(s1,s2)
 end
 
 for input, output in pairs(testCases) do
-    local res = sliding(input)
+    local res = scanRight(unpack(input))
     assert(eq(res,output),("failed for %q, expected {%s} got {%s}"):format(input,table.concat(output,", "),table.concat(res,", ")))
 end

--- a/scanning/problem.lua
+++ b/scanning/problem.lua
@@ -48,5 +48,11 @@ end
 
 for input, output in pairs(testCases) do
     local res = scanRight(unpack(input))
-    assert(eq(res,output),("failed for %q, expected {%s} got {%s}"):format(input,table.concat(output,", "),table.concat(res,", ")))
+    assert(eq(res,output),("failed for ({%s}, %d, %q), expected {%s} got {%s}"):format(
+        table.concat(input[1], ", "),
+        input[2],
+        tostring(input[3])    
+        table.concat(output,", "),
+        table.concat(res,", "))
+    )
 end


### PR DESCRIPTION
Inputs need to be unpacked, as the given signature of the `scanRight` function is `
local function scanRight(arr, init, op)`.

`%q` is the wrong format specifier.